### PR TITLE
Greatly simplify build process for api-docs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,23 +1,5 @@
 version: 2
 jobs:
-  check_dev_master_pr:
-    docker:
-      - image: circleci/node:10-stretch-browsers
-    working_directory: ~/lumahealthhq/rest-service-docs
-    environment:
-      CIRCLE_ARTIFACTS: /tmp/circleci-artifacts
-      CIRCLE_TEST_REPORTS: /tmp/circleci-test-results
-      NODE_ENV: default
-    steps:
-    - run: |
-        if [ $(echo "$CIRCLE_BRANCH" | grep -c "dev") -gt 0 ] || [ $(echo "$CIRCLE_BRANCH" | grep -c "master") -gt 0 ]; then
-          curl --user $CIRCLE_API_PROJECT_TOKEN: \
-            --data build_parameters[CIRCLE_JOB]=build-deploy-s3 \
-            --data revision=$CIRCLE_SHA1 \
-            https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-        else
-          exit 0;
-        fi
   build-deploy-s3:
     docker:
       - image: circleci/ruby:2.6-stretch
@@ -28,10 +10,14 @@ jobs:
     - run: sudo gem install bundler -v 1.15.4
     - run: bundle install
     - run: bundle exec middleman build --clean
-    - run: aws s3 sync build/ s3://lumahealth-api-docs --acl public-read
+    - run: aws s3 sync build/ s3://lumahealth-api-docs
 workflows:
   version: 2
   main:
     jobs:
-      - check_dev_master_pr
-
+      - build-deploy-s3
+          filters:
+            branches:
+              only:
+                - master
+                - dev

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,7 +15,7 @@ workflows:
   version: 2
   main:
     jobs:
-      - build-deploy-s3
+      - build-deploy-s3:
           filters:
             branches:
               only:


### PR DESCRIPTION
- Use branch filtering rather than a nasty series of shell commands to do the same thing
- Drop `--acl public-read` as it's effectively a no-op these days